### PR TITLE
Added .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+ - id: sqlvalidator
+   name: sqlvalidator
+   description: SQL queries formatting, syntactic and semantic validation
+   entry: sqlvalidator
+   language: python
+   minimum_pre_commit_version: 2.6.0
+   require_serial: true
+   types: [python]
+   args: [--format]


### PR DESCRIPTION
The PR adds a file that describes how to use this tool with [pre-commit](https://pre-commit.com/index.html). With this file included in the repo, we can install `sqlvalidator` as a pre-commit hook to be run before all commits.