### PR TITLE
Add .pre-commit-hooks.yaml for use with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: sqlvalidator
+  name: sqlvalidator
+  description: Validate SQL snippets inside Python code.
+  entry: sqlvalidator --format
+  language: python
+  types: [python]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ Validation contains:
 * https://www.postgresql.org/docs/9.6/sql-select.html
 * https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
 
+## Use with [pre-commit](https://pre-commit.com)
+
+Add this to your `.pre-commit-config.yaml`:
+```yaml
+  - repo: https://github.com/David-Wobrock/sqlvalidator
+    rev: <sha1 of the latest sqlvalidator commit>
+    hooks:
+      - id: sqlvalidator
+```
+
 ## Contributing
 
 If you want to contribute to the sqlvalidator, first, thank you for the interest.


### PR DESCRIPTION
Hi :wave: 

This PR is not necessary to use [pre-commit](https://pre-commit.com) with sqlvalidator, we can already do it with:

```yaml
  - repo: local
    hooks:
      - id: sqlvalidator
        name: sqlvalidator
        entry: sqlvalidator --format
        language: python
        types: [python]
        additional_dependencies:
          - "sqlvalidator==0.0.16"
```

But with this PR, we'll be able to do:
```yaml
  - repo: https://github.com/David-Wobrock/sqlvalidator
    rev: b88cee961f75b5f6e404b39b68c4b37174d4704b
    hooks:
      - id: sqlvalidator
```

That said, it would be much easier if releases were tagged so we could use `rev: <tag name>`

It's not tested yet, but I'll bump when we're clear.

When it's merged, we can make a PR to add this repo to https://github.com/pre-commit/pre-commit.com/blob/main/all-repos.yaml