### PR TITLE
Added support to tab as token separator. 

### DIFF
--- a/sqlvalidator/grammar/tokeniser.py
+++ b/sqlvalidator/grammar/tokeniser.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 STRING_SPLIT_TOKENS = ("'", '"', "`")
-WHITESPACE_SPLIT_TOKENS = (" ", "\n")
+WHITESPACE_SPLIT_TOKENS = (" ", "\n", "\t")
 KEPT_SPLIT_TOKENS = (
     ",",
     ";",

--- a/tests/integration/test_validation.py
+++ b/tests/integration/test_validation.py
@@ -561,3 +561,8 @@ SELECT * REPLACE ("x" AS col)
 FROM (select field from t)
 """
     assert_invalid_sql(sql)
+
+
+def test_tab_as_token_separator():
+    sql = "\tSELECT * FROM\ttable"
+    assert_valid_sql(sql)


### PR DESCRIPTION
Hi David,

This code adds support for the tab as a query token separator.

Currently, sqlvalidator fails with queries containing tabs.
Tab '\t' is a valid token separator according to https://www.postgresql.org/docs/8.1/sql-syntax.html#SQL-SYNTAX-LEXICAL

A test case was also added asserting the issue.

Thanks.