### PR TITLE
Add interval expression

### DIFF
--- a/sqlvalidator/grammar/sql.py
+++ b/sqlvalidator/grammar/sql.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, List, Optional, Set
+from typing import Any, List, Optional, Set, Union
 
 from sqlvalidator.grammar.tokeniser import lower
 
@@ -1163,7 +1163,7 @@ class Table(Expression):
 
 class Unnest(Expression):
     def __init__(self, unnest_expression, with_offset, with_offset_as, offset_alias):
-        # unnest_expression: can be functiion call or alias of function call
+        # unnest_expression: can be function call or alias of function call
         super().__init__(unnest_expression)
         self.with_offset = with_offset
         self.with_offset_as = with_offset_as
@@ -1598,3 +1598,62 @@ class Case(Expression):
             case_str += "\n ELSE {}".format(transform(self.else_expression))
         case_str += "\nEND"
         return case_str
+
+
+class DateTimePart(Expression):
+    PARTS = (
+        "year",
+        "quarter",
+        "month",
+        "week",
+        "day",
+        "hour",
+        "minute",
+        "second",
+        "millisecond",
+        "microsecond",
+    )
+
+    def __init__(self, expression: str, ending_datetime_part: Union[str, None] = None):
+        super().__init__(expression.upper())
+        self.ending_datetime_part = (
+            ending_datetime_part.upper() if ending_datetime_part is not None else None
+        )
+
+    def __repr__(self):
+        return "<DateTimePart: {} range: {}>".format(
+            self.value, self.ending_datetime_part
+        )
+
+    def __eq__(self, other):
+        return (
+            type(self) == type(other)
+            and self.value == other.value
+            and self.ending_datetime_part == other.ending_datetime_part
+        )
+
+    def __str__(self):
+        return (
+            "{}".format(self.value)
+            if self.ending_datetime_part is None
+            else "{} TO {}".format(self.value, self.ending_datetime_part)
+        )
+
+
+class Interval(Expression):
+    def __init__(self, interval, datetime_part):
+        self.interval = interval
+        self.datetime_part = datetime_part
+
+    def __repr__(self):
+        return "<Interval: {} {}>".format(self.interval, repr(self.datetime_part))
+
+    def __eq__(self, other):
+        return (
+            type(self) == type(other)
+            and self.interval == other.interval
+            and self.datetime_part == other.datetime_part
+        )
+
+    def __str__(self):
+        return "INTERVAL {} {}".format(self.interval, self.datetime_part)

--- a/tests/integration/test_formatting.py
+++ b/tests/integration/test_formatting.py
@@ -2205,3 +2205,27 @@ END
 FROM table
 """
     assert format_sql(sql) == expected.strip()
+
+
+def test_interval_with_single_datetime_part():
+    sql = """select value
+    from table
+    where date(date) >= date_sub(current_date(), interval -5 hour)"""
+    expected = """
+SELECT value
+FROM table
+WHERE DATE(date) >= DATE_SUB(CURRENT_DATE(), INTERVAL -5 HOUR)
+"""
+    assert format_sql(sql) == expected.strip()
+
+
+def test_interval_with_datetime_part_range():
+    sql = """select value
+    from table
+    where date(date) >= date_sub(current_date(), interval '8 20 17' month to hour)"""
+    expected = """
+SELECT value
+FROM table
+WHERE DATE(date) >= DATE_SUB(CURRENT_DATE(), INTERVAL '8 20 17' MONTH TO HOUR)
+"""
+    assert format_sql(sql) == expected.strip()

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -16,11 +16,13 @@ from sqlvalidator.grammar.sql import (
     Column,
     Condition,
     CountFunctionCall,
+    DateTimePart,
     ExceptClause,
     FunctionCall,
     GroupByClause,
     Index,
     Integer,
+    Interval,
     Join,
     LimitClause,
     Null,
@@ -965,4 +967,28 @@ def test_chained_columns_with_arithmetic_operator():
 def test_function_with_single_comma_string_param():
     actual, _ = ExpressionParser.parse(to_tokens("test(',')"))
     expected = FunctionCall("test", String(",", quotes="'"))
+    assert actual == expected
+
+
+def test_interval_with_single_datetime_part():
+    actual, _ = ExpressionParser.parse(to_tokens("INTERVAL -1 MONTH"))
+    expected = Interval(Integer(-1), DateTimePart("MONTH"))
+    assert actual == expected
+
+
+def test_interval_with_datetime_part_range():
+    actual, _ = ExpressionParser.parse(to_tokens("INTERVAL '8 -20 17' MONTH TO HOUR"))
+    expected = Interval(String("8 -20 17", quotes="'"), DateTimePart("MONTH", "HOUR"))
+    assert actual == expected
+
+
+def test_interval_in_function():
+    actual, _ = ExpressionParser.parse(
+        to_tokens("TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 30 SECOND)")
+    )
+    expected = FunctionCall(
+        "TIMESTAMP_ADD",
+        FunctionCall("CURRENT_TIMESTAMP"),
+        Interval(Integer(30), DateTimePart("SECOND")),
+    )
     assert actual == expected


### PR DESCRIPTION
The current version doesn't handle well the interval statement.
If we try to validate this SQL code:
```sql
SELECT * FROM table WHERE date >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
```
we lose the day parameter of the interval, here is what is output:
```sql
SELECT *
FROM table
WHERE date >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7)
```

With this PR we will stop losing the unit of time.